### PR TITLE
Use standard *nix status errors

### DIFF
--- a/bleed.go
+++ b/bleed.go
@@ -10,13 +10,13 @@ func main() {
 	out, err := bleed.Heartbleed(os.Args[1], []byte("heartbleed.filippo.io"))
 	if err == bleed.ErrPayloadNotFound {
 		log.Printf("%v - SAFE", os.Args[1])
-		os.Exit(1)
+		os.Exit(0)
 	} else if err != nil {
 		log.Printf("%v - ERROR: %v", os.Args[1], err)
 		os.Exit(2)
 	} else {
 		log.Printf("%v\n", string(out))
 		log.Printf("%v - VULNERABLE", os.Args[1])
-		os.Exit(0)
+		os.Exit(1)
 	}
 }


### PR DESCRIPTION
In *nix standards, `0` means the process exited successfully,
which makes more sense when a site is SAFE.
