### PR TITLE
change text "handshare failure" to "handshake failure or TLS extension not supported"

### DIFF
--- a/tls/alert.go
+++ b/tls/alert.go
@@ -46,7 +46,7 @@ var alertText = map[alert]string{
 	alertDecryptionFailed:       "decryption failed",
 	alertRecordOverflow:         "record overflow",
 	alertDecompressionFailure:   "decompression failure",
-	alertHandshakeFailure:       "handshake failure",
+	alertHandshakeFailure:       "handshake failure. This could mean that the TLS extension is not supported.",
 	alertBadCertificate:         "bad certificate",
 	alertUnsupportedCertificate: "unsupported certificate",
 	alertCertificateRevoked:     "revoked certificate",


### PR DESCRIPTION
I do see "handshake failure" for servers which do not offer TLS, so the text should inform about this possibility.alertHandshakeFailure: "handshake failure. This could mean that the TLS extension is not supported.",

I haven't tested this code change yet.
