### PR TITLE
parse passed host before using

### DIFF
--- a/bleed_serve.go
+++ b/bleed_serve.go
@@ -33,7 +33,7 @@ func bleedHandler(w http.ResponseWriter, r *http.Request) {
 	host := r.URL.Path[len("/bleed/"):]
 	u, err := url.Parse(host)
 	if err == nil {
-		host := u.Host
+		host = u.Host
 	}
 	if strings.Index(host, ":") == -1 {
 		host = host + ":443"


### PR DESCRIPTION
This uses the net/url package to attempt to parse a url scheme before falling back to the raw string passed.

Same as the PR for the python version
