### PR TITLE
Fix compilation error on OSX 10.9.2 running basic cmdline tools

### DIFF
--- a/bleed.go
+++ b/bleed.go
@@ -55,8 +55,7 @@ func main() {
 		if err.Error() == "Please try again" {
 			log.Printf("%v - TRYAGAIN: %v", tgt.HostIp, err)
 			os.Exit(2)
-		}
-	 	else {
+		} else {
 			log.Printf("%v - ERROR: %v", tgt.HostIp, err)
 			os.Exit(2)
 		}


### PR DESCRIPTION
go version go1.2.1 darwin/amd64

Robs-MacBook-Air:~ rtshanks$ go get github.com/FiloSottile/Heartbleed
src/go/src/github.com/FiloSottile/Heartbleed/bleed.go:59: syntax error:
unexpected semicolon or newline before else
src/go/src/github.com/FiloSottile/Heartbleed/bleed.go:63: syntax error:
unexpected else, expecting semicolon or newline
src/go/src/github.com/FiloSottile/Heartbleed/bleed.go:65:
non-declaration statement outside function body
src/go/src/github.com/FiloSottile/Heartbleed/bleed.go:66:
non-declaration statement outside function body
src/go/src/github.com/FiloSottile/Heartbleed/bleed.go:67: syntax error:
unexpected }
